### PR TITLE
Add Makefile target to install dev-dependencies, like d3js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ test: all
 package.json: science.js src/package.js
 	node src/package.js > $@
 
+install:
+	mkdir -p node_modules
+	npm install
+
 science.js science%.js: Makefile
 	@rm -f $@
 	cat $(filter %.js,$^) > $@

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Currently, there are two modules:
    similar to those provided by [R](http://www.r-project.org/);
  * `science.lin`, for linear algebra.
 
+## Development
+
+To help develop Science.js, you need to have [Node.js](http://www.nodejs.org) and [NPM](http://www.npmjs.org) installed. Once you have done that, run the following from the root directory of this repository to install the development dependencies:
+
+    make install
+
 ## Thanks
 
 I originally started this in order to add a reusable statistics module to


### PR DESCRIPTION
Since it is mentioned in the README that the project structure is taking after d3js. I actually find this setup much cleaner (installing `node_modules` in the repository directory tree).
