### PR TITLE
Remove deprecated syntax

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -1,6 +1,6 @@
 require("./core/core");
 
-require("util").puts(JSON.stringify({
+console.log(JSON.stringify({
   "name": "science",
   "version": science.version,
   "description": "Scientific and statistical computing in JavaScript.",


### PR DESCRIPTION
Hi,
the previous syntax doesn't work for Node.js >= 12. I fixed it switching to newer syntax so as to build with all versions of Node.js. 
Thanks!